### PR TITLE
Improve leader election.

### DIFF
--- a/pkg/startup.go
+++ b/pkg/startup.go
@@ -2,6 +2,8 @@ package pkg
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"net/http"
 	"os"
 	"time"
@@ -44,14 +46,16 @@ func Run() {
 	ctr := controller.Setup()
 
 	id := os.Getenv("POD_NAME")
+	shaPodName := sha256.Sum256([]byte(id))
+	id = id + "-" + hex.EncodeToString(shaPodName[:])[:8]
 
 	lock := NewLock(LeaderElectionLockName, id, LeaderElectionNamespace, client)
 
 	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
 		Lock:            lock,
 		ReleaseOnCancel: true,
-		LeaseDuration:   15 * time.Second,
-		RenewDeadline:   10 * time.Second,
+		LeaseDuration:   30 * time.Second,
+		RenewDeadline:   15 * time.Second,
 		RetryPeriod:     2 * time.Second,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(_ context.Context) {

--- a/pkg/startup.go
+++ b/pkg/startup.go
@@ -54,9 +54,9 @@ func Run() {
 	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
 		Lock:            lock,
 		ReleaseOnCancel: true,
-		LeaseDuration:   30 * time.Second,
+		LeaseDuration:   60 * time.Second,
 		RenewDeadline:   15 * time.Second,
-		RetryPeriod:     2 * time.Second,
+		RetryPeriod:     5 * time.Second,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(_ context.Context) {
 				log.Infof("Started leading.")


### PR DESCRIPTION
This PR for improving naming in leader election and also redefining `LeaderElectionConfig` such as LeaseDuration. Because LeaseDuration was so short it was causing problems like:

```log
leaderelection.go:364] Failed to update lock: Operation cannot be fulfilled on leases.coordination.k8s.io "node-wizard-lock": the object has been modified; please apply your changes to the latest version and try again
```

In the future maybe we could consider to parametrize LeaderElectionConfig.