### PR TITLE
Get the LeaderElectionNamespace from pod Manifest

### DIFF
--- a/pkg/startup.go
+++ b/pkg/startup.go
@@ -18,8 +18,7 @@ import (
 )
 
 const (
-	LeaderElectionLockName  string = "node-wizard-lock"
-	LeaderElectionNamespace string = "node-wizard"
+	LeaderElectionLockName string = "node-wizard-lock"
 )
 
 func Run() {
@@ -27,6 +26,11 @@ func Run() {
 	client, err := utils.GetKubernetesClient()
 	if err != nil {
 		log.Fatalf("Error getting kubernetes client: %v", err)
+	}
+	// Get the namespace of the pod
+	LeaderElectionNamespace := os.Getenv("POD_NAMESPACE")
+	if LeaderElectionNamespace == "" {
+		log.Fatalf("Error getting namespace of the pod")
 	}
 
 	go func() {


### PR DESCRIPTION
Hi, 

I realized that when I install the chart other than namespace "node-wizard" I was getting the error below and then figure out that the leader election namespace was hardcoded below. Instead of hardcoding it, I thought it might be better to put it to pod manifest as parametrized ( or using environment variable ) and then grab it from there. Also according to that, I've also created a  [PR](https://github.com/cnwizards/helm-charts/pull/2) for the helm chart as well. 

`I0717 20:09:59.824276       1 leaderelection.go:245] attempting to acquire leader lease node-wizard/node-wizard-lock...
E0717 20:09:59.949270       1 leaderelection.go:331] error initially creating leader election record: namespaces "node-wizard" not found
E0717 20:10:05.133072       1 leaderelection.go:331] error initially creating leader election record: namespaces "node-wizard" not found
E0717 20:10:09.429363       1 leaderelection.go:331] error initially creating leader election record: namespaces "node-wizard" not found
`

